### PR TITLE
Update home-server-actions.yml: better regex to search for bot process

### DIFF
--- a/.github/workflows/home-server-actions.yml
+++ b/.github/workflows/home-server-actions.yml
@@ -62,10 +62,10 @@ jobs:
           command_timeout: 5m
         # script_stop: true
           envs: IS_PRODUCTION , DIR , BARD_APIKEY , DISCORDBOTTOKEN_GPTEOUS , OPENAI_APIKEY , DEEPSEEK_APIKEY , BARD_GMAIL , BARD_GMAILPASS #passes them to server put doesnt save them this which is good!
-          script: | 
+          script: |
             # set -e  # Exit immediately on error
             echo "Starting bot deployment..."
-            if pgrep -f "bot_wizy_discord.py" >/dev/null; then
+            if pgrep -f "[b]ot_wizy_discord.py" >/dev/null; then
               echo "terminating old wizy... system daemon will auto restart it!"
-              pkill -f bot_wizy_discord.py
+              pkill -f "[b]ot_wizy_discord.py"
             fi


### PR DESCRIPTION
1. The Danger of the -f (Full) Flag
Normally, if you run pgrep python, Linux only searches the actual names of the running programs.

But when you add the -f flag (pgrep -f), you are telling Linux: "Don't just look at the program name. Look at the entire command line string that was typed to launch the process."

2. How GitHub Actions Runs Your Script
When the appleboy/ssh-action connects to your server, it doesn't just create a file and run it. It wraps your entire script: | block into one massive text string and passes it directly into a bash shell over SSH.

If you were to look at your server's active processes using ps aux at the exact millisecond your deployment is running, you wouldn't see a script named deploy.sh. Instead, you would see a system process that looks something like this:

Bash
bash -c "echo 'Starting bot deployment...'; if pgrep -f 'bot_wizy_discord.py' >/dev/null; then echo 'terminating...'; pkill -f 'bot_wizy_discord.py'; fi"
3. The Fatal Match (Process Suicide)
Because of the -f flag, pgrep and pkill scan the entire command line of every process on the server.

pkill looks at that massive bash -c process running your SSH session.

It scans through the text of that process.

It spots the exact sequence of letters: bot_wizy_discord.py sitting right there inside the if statement.

pkill thinks, "Aha! I found a process containing that string!" and it immediately kills the SSH bash shell.

This severs the connection mid-stride, which is why your GitHub Actions runner immediately crashes with an exit code 1.

Summary: Why the Bracket Trick [b] works
When you change the command to pkill -f "[b]ot_wizy_discord.py", the SSH bash process on your server now looks like this:

Bash
bash -c "... pkill -f '[b]ot_wizy_discord.py' ..."
When pkill scans the processes, it is looking for the literal text bot_wizy_discord.py. It looks at the SSH shell, sees [b]ot_wizy_discord.py, realizes the brackets mean it is not an exact match, ignores the shell, and safely continues running your deployment!